### PR TITLE
Correct comment syntax in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,11 +1,9 @@
-/*
- * ----------------------------------------------------------------------------
- * "THE BEER-WARE LICENSE" (Revision 42):
- * <jonas@jalling.dk> wrote this file.  As long as you retain this notice you
- * can do whatever you want with this stuff. If we meet some day, and you think
- * this stuff is worth it, you can buy me a beer in return.   Jonas Bo Jalling
- * ----------------------------------------------------------------------------
- */
+# ----------------------------------------------------------------------------
+# "THE BEER-WARE LICENSE" (Revision 42):
+# <jonas@jalling.dk> wrote this file.  As long as you retain this notice you
+# can do whatever you want with this stuff. If we meet some day, and you think
+# this stuff is worth it, you can buy me a beer in return.   Jonas Bo Jalling
+# ----------------------------------------------------------------------------
 #######################################
 # Syntax Coloring Map For Si7005
 #######################################


### PR DESCRIPTION
keywords.txt uses # for comments.